### PR TITLE
fix fullscreen imgui

### DIFF
--- a/src/graphics/dx9.cpp
+++ b/src/graphics/dx9.cpp
@@ -17,6 +17,10 @@ HRESULT __stdcall dx9::hook_end_scene(IDirect3DDevice9* device) noexcept
         gui::SetupMenu(device);
     }
 
+    if (gui::device != device) {
+        gui::Reset(device);
+    }
+
     gui::Render();
 
     return result;
@@ -33,8 +37,8 @@ HRESULT __stdcall dx9::hook_reset(IDirect3DDevice9* device, D3DPRESENT_PARAMETER
 
 void dx9::Setup()
 {
-    end_scene_hook = safetyhook::create_inline(VirtualFunction(gui::device, 42), reinterpret_cast<void*>(hook_end_scene));
-    reset_hook = safetyhook::create_inline(VirtualFunction(gui::device, 16), reinterpret_cast<void*>(hook_reset));
+    end_scene_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 42), reinterpret_cast<void*>(hook_end_scene));
+    reset_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 16), reinterpret_cast<void*>(hook_reset));
 }
 
 void dx9::Destroy() noexcept

--- a/src/graphics/gui.cpp
+++ b/src/graphics/gui.cpp
@@ -120,7 +120,7 @@ bool gui::SetupDirectX() noexcept
         window,
         D3DCREATE_SOFTWARE_VERTEXPROCESSING | D3DCREATE_DISABLE_DRIVER_MANAGEMENT,
         &params,
-        &device
+        &dummyDevice
     ) != S_OK)
         return false;
 
@@ -129,10 +129,10 @@ bool gui::SetupDirectX() noexcept
 
 void gui::DestroyDirectX() noexcept
 {
-    if (device)
+    if (dummyDevice)
     {
-        device->Release();
-        device = NULL;
+        dummyDevice->Release();
+        dummyDevice = NULL;
     }
 
     if (d3d9)
@@ -202,6 +202,21 @@ void gui::Destroy()
     );
 
     DestroyDirectX();
+}
+
+void gui::Reset(LPDIRECT3DDEVICE9 newDevice)
+{
+    D3DDEVICE_CREATION_PARAMETERS params;
+    newDevice->GetCreationParameters(&params);
+
+    ImGui_ImplWin32_Shutdown();
+    ImGui_ImplWin32_Init(params.hFocusWindow);
+
+    ImGui_ImplDX9_Shutdown();
+    ImGui_ImplDX9_Init(newDevice);
+
+    window = params.hFocusWindow;
+    device = newDevice;
 }
 
 void gui::Render()

--- a/src/graphics/gui.h
+++ b/src/graphics/gui.h
@@ -19,6 +19,7 @@ namespace gui {
 
     // directX stuff
     inline LPDIRECT3DDEVICE9 device = nullptr;
+    inline LPDIRECT3DDEVICE9 dummyDevice = nullptr;
     inline LPDIRECT3D9 d3d9 = nullptr;
     inline int* internal_resolution = reinterpret_cast<int*>(offsets::internal_resolution);
 
@@ -35,6 +36,7 @@ namespace gui {
 
     void SetupMenu(LPDIRECT3DDEVICE9 device) noexcept;
     void Destroy();
+    void Reset(LPDIRECT3DDEVICE9 device);
 
     void Render();
 }


### PR DESCRIPTION
adds gui::Reset() and a call to it from EndScene hook, so ImGui can reinitialize in case LR2 recreated directx9 device.