### PR TITLE
fix for DgVoodoo

### DIFF
--- a/src/features/totaltime.cpp
+++ b/src/features/totaltime.cpp
@@ -1,21 +1,25 @@
 #include "totaltime.h"
 
-int totaltimenum = *(int*)(totaltime::totaltimeptr);
-
 int totaltime::GetHours()
 {
-	int totalhours = totaltimenum / 3600;
+	int totaltimenum = *(int*)(totaltime::totaltimeptr);
+
+	int totalhours = (int)(totaltimenum / 3600);
 	return totalhours;
 }
 
 int totaltime::GetMinutes()
 {
-	int totalminutes = totaltimenum / 60 % 60;
+	int totaltimenum = *(int*)(totaltime::totaltimeptr);
+
+	int totalminutes = (int)(totaltimenum / 60 % 60);
 	return totalminutes;
 }
 
 int totaltime::GetSeconds()
 {
-	int totalseconds = totaltimenum % 60;
+	int totaltimenum = *(int*)(totaltime::totaltimeptr);
+
+	int totalseconds = (int)(totaltimenum % 60);
 	return totalseconds;
 }

--- a/src/graphics/gui.cpp
+++ b/src/graphics/gui.cpp
@@ -116,7 +116,7 @@ bool gui::SetupDirectX() noexcept
 
     if (d3d9->CreateDevice(
         D3DADAPTER_DEFAULT,
-        D3DDEVTYPE_NULLREF,
+        D3DDEVTYPE_HAL,
         window,
         D3DCREATE_SOFTWARE_VERTEXPROCESSING | D3DCREATE_DISABLE_DRIVER_MANAGEMENT,
         &params,


### PR DESCRIPTION
tldr dgvoodoo doesn't have D3DDEVTYPE_NULLREF which results in imgui shitting itself and then whole lr2 collapses