### PR TITLE
move scene init switch hook for real scene idx

### DIFF
--- a/src/hooks/updategamestate.cpp
+++ b/src/hooks/updategamestate.cpp
@@ -6,7 +6,7 @@ void hooks::updategamestate::Install()
 {
     gamestate_hook = safetyhook::create_mid(reinterpret_cast<void*>(offsets::change_gamestate), [](safetyhook::Context& ctx) {
         gamestate = static_cast<GAMESTATE>(ctx.eax);
-        if (static_cast<int>(gamestate) == 13 - 2) gamestate = GAMESTATE::result;
+        if (static_cast<int>(gamestate) == 13) gamestate = GAMESTATE::result;
         if (gamestate == GAMESTATE::playing) {
             /* manually setting this variable feels inconsistent given precense of helper functions */
             hiterror::open = true;

--- a/src/hooks/updategamestate.h
+++ b/src/hooks/updategamestate.h
@@ -3,14 +3,14 @@
 
 namespace hooks::updategamestate {
 	namespace offsets {
-		const inline uintptr_t change_gamestate = 0x431BB9;
+		const inline uintptr_t change_gamestate = 0x431BB6;
 	};
 	/* todo: fill this out with other values */
 	enum class GAMESTATE {
-		select = 0,
-		decide = 1,
-		playing = 2,
-		result = 3
+		select = 2,
+		decide = 3,
+		playing = 4,
+		result = 5
 	};
 
 	inline GAMESTATE gamestate = GAMESTATE::select;


### PR DESCRIPTION
Moves hook to before 'add eax,-2' is ran, as this is likely a compiler optimization, and real value passed into a switch isn't that. For example, real index for select scene is not 0, but 2 in LR2 code, as seen everywhere else around its code.

This caused a problem of compatibility with LR2HackBox, which hooked 3 bytes earlier (same address as in this PR), as LR2OOL hooked after LR2HackBox and broke the 5 bytes long jmp instruction (can't set hook correctly in the middle of instruction). I don't want to modify LR2HackBox to solve this, as I believe this is the most correct and efficient place to hook this switch.