### PR TITLE
bga fix for upscalr2

### DIFF
--- a/src/graphics/dx9.cpp
+++ b/src/graphics/dx9.cpp
@@ -8,55 +8,71 @@
 
 #include "dx9.h"
 
-static int sceneIdx = 0;
+struct SceneDesc {
+    struct int2 {
+        int x = 0;
+        int y = 0;
+
+        auto operator<=>(const int2&) const = default;
+    };
+    int2 canvasSize;
+    int2 outputSize;
+    SceneDesc(int canvasX, int canvasY, int outputX, int outputY) :
+        canvasSize(canvasX, canvasY), outputSize(outputX, outputY) {
+    };
+};
+
+static int sceneIdx = -1;
+static int sceneTarget = -1;
+static std::vector<SceneDesc> scenes;
 HRESULT __stdcall dx9::hook_present(LPDIRECT3DSWAPCHAIN9 pSwapchain, const RECT* pSourceRect, const RECT* pDestRect, HWND hDestWindowOverride, const RGNDATA* pDirtyRegion, DWORD dwFlags) noexcept
 {
-    sceneIdx = 0;
+    if (!scenes.empty()) {
+        int target = scenes.size() - 1;
+        if (scenes.size() > 1) {
+            if (scenes[target].canvasSize != scenes[target - 1].canvasSize) target--;
+        }
+        sceneTarget = target;
+        scenes.clear();
+    }
+    sceneIdx = -1;
     return present_hook.stdcall<HRESULT>(pSwapchain, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);
 }
 
 HRESULT __stdcall dx9::hook_end_scene(IDirect3DDevice9* device) noexcept
 {
-    int curSceneIdx = sceneIdx;
-    sceneIdx++;
-    if (curSceneIdx != 0) return end_scene_hook.stdcall<HRESULT>(device);
-
     if (!gui::setup) {
         gui::SetupMenu(device);
     }
 
     gui::Reset(device);
 
-    if (IsIconic(gui::window)) return end_scene_hook.stdcall<HRESULT>(device);
-
-    std::vector<IDirect3DSurface9*> rts{};
-    rts.reserve(gui::rtMax);
-    for (int i = 0; i < rts.capacity(); i++) {
-        IDirect3DSurface9* rt{};
-        device->GetRenderTarget(i, &rt);
-        rts.push_back(rt);
-        if (i != 0) device->SetRenderTarget(i, NULL);
-    }
     D3DSURFACE_DESC canvas{};
-    rts[0]->GetDesc(&canvas);
-
-    IDirect3DSurface9* backbuffer{};
+    {
+        IDirect3DSurface9* rt{};
+        device->GetRenderTarget(0, &rt);
+        rt->GetDesc(&canvas);
+        rt->Release();
+    }
     D3DSURFACE_DESC output{};
-    device->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &backbuffer);
-    backbuffer->GetDesc(&output);
-    backbuffer->Release();
+    {
+        IDirect3DSurface9* backbuffer{};
+        device->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &backbuffer);
+        backbuffer->GetDesc(&output);
+        backbuffer->Release();
+    }
+    scenes.emplace_back(canvas.Width, canvas.Height, output.Width, output.Height);
+
+    sceneIdx++;
+    if (sceneIdx != sceneTarget) return end_scene_hook.stdcall<HRESULT>(device);
+
+    if (IsIconic(gui::window)) return end_scene_hook.stdcall<HRESULT>(device);
 
     gui::internal_resolution[0] = canvas.Width;
     gui::internal_resolution[1] = canvas.Height;
     gui::output_resolution[0] = output.Width;
     gui::output_resolution[1] = output.Height;
     gui::Render();
-
-    for (int i = 0; i < rts.size(); i++) {
-        auto& rt = rts[i];
-        device->SetRenderTarget(i, rt);
-        if (rt) rt->Release();
-    }
 
     return end_scene_hook.stdcall<HRESULT>(device);
 }
@@ -74,14 +90,31 @@ HRESULT __stdcall dx9::hook_reset(IDirect3DDevice9* device, D3DPRESENT_PARAMETER
     return result;
 }
 
+HRESULT __stdcall dx9::hook_resetEx(IDirect3DDevice9Ex* device, D3DPRESENT_PARAMETERS* params, D3DDISPLAYMODEEX* display)
+{
+    if (device == NULL) {
+        return resetEx_hook.stdcall<HRESULT>(device, params, display);
+    }
+
+    ImGui_ImplDX9_InvalidateDeviceObjects();
+    const auto result = resetEx_hook.stdcall<HRESULT>(device, params, display);
+    if (SUCCEEDED(result)) ImGui_ImplDX9_CreateDeviceObjects();
+
+    return result;
+}
+
 void dx9::Setup()
 {
-    end_scene_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 42), reinterpret_cast<void*>(hook_end_scene));
-    reset_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 16), reinterpret_cast<void*>(hook_reset));
+    present_hook = safetyhook::create_inline(VirtualFunction(gui::dummySwapchain, 3), hook_present);
+    end_scene_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 42), hook_end_scene);
+    reset_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 16), hook_reset);
+    resetEx_hook = safetyhook::create_inline(VirtualFunction(gui::dummyDevice, 132), hook_resetEx);
 }
 
 void dx9::Destroy() noexcept
 {
+    present_hook = {};
     end_scene_hook = {};
-    //reset_hook = {};
+    reset_hook = {};
+    resetEx_hook = {};
 }

--- a/src/graphics/dx9.h
+++ b/src/graphics/dx9.h
@@ -7,10 +7,12 @@ namespace dx9
     inline SafetyHookInline present_hook = {};
     inline SafetyHookInline end_scene_hook = {};
     inline SafetyHookInline reset_hook = {};
+    inline SafetyHookInline resetEx_hook = {};
 
     HRESULT __stdcall hook_present(LPDIRECT3DSWAPCHAIN9 pSwapchain, const RECT* pSourceRect, const RECT* pDestRect, HWND hDestWindowOverride, const RGNDATA* pDirtyRegion, DWORD dwFlags) noexcept;
     HRESULT __stdcall hook_end_scene(IDirect3DDevice9* device) noexcept;
     HRESULT __stdcall hook_reset(IDirect3DDevice9* device, D3DPRESENT_PARAMETERS* params);
+    HRESULT __stdcall hook_resetEx(IDirect3DDevice9Ex* device, D3DPRESENT_PARAMETERS* params, D3DDISPLAYMODEEX* display);
 
     constexpr void* VirtualFunction(void* thisptr, size_t index) noexcept
     {

--- a/src/graphics/gui.cpp
+++ b/src/graphics/gui.cpp
@@ -84,46 +84,41 @@ bool gui::SetupDirectX() noexcept
         Sleep(10);
     } while (!handle);
 
-    using CreateFn = LPDIRECT3D9(__stdcall*)(UINT);
+    using CreateFn = HRESULT(__stdcall*)(UINT, LPDIRECT3D9EX*);
     CreateFn create = nullptr;
     do { 
         create = reinterpret_cast<CreateFn>(GetProcAddress(
         handle,
-        "Direct3DCreate9"
+        "Direct3DCreate9Ex"
         ));
         Sleep(10);
     } while (!create);
 
-    d3d9 = create(D3D_SDK_VERSION);
+    create(D3D_SDK_VERSION, &d3d9);
 
     if (!d3d9)
         return false;
 
     D3DPRESENT_PARAMETERS params = { };
-    params.BackBufferWidth = 0;
-    params.BackBufferHeight = 0;
-    params.BackBufferFormat = D3DFMT_UNKNOWN;
-    params.BackBufferCount = 0;
-    params.MultiSampleType = D3DMULTISAMPLE_NONE;
-    params.MultiSampleQuality = NULL;
-    params.SwapEffect = D3DSWAPEFFECT_DISCARD;
-    params.hDeviceWindow = window;
     params.Windowed = 1;
-    //params.Windowed = (GetWindowLongPtr(params.hDeviceWindow, GWL_STYLE) & WS_POPUP) != 0 ? FALSE : TRUE;;
-    params.EnableAutoDepthStencil = 0;
-    params.AutoDepthStencilFormat = D3DFMT_UNKNOWN;
-    params.Flags = NULL;
-    params.FullScreen_RefreshRateInHz = 0;
-    params.PresentationInterval = 0;
+    params.SwapEffect = D3DSWAPEFFECT_FLIP;
+    params.BackBufferFormat = D3DFMT_A8R8G8B8;
+    params.BackBufferCount = 1;
+    params.hDeviceWindow = window;
+    params.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
 
-    if (d3d9->CreateDevice(
+    if (d3d9->CreateDeviceEx(
         D3DADAPTER_DEFAULT,
         D3DDEVTYPE_HAL,
         window,
-        D3DCREATE_SOFTWARE_VERTEXPROCESSING | D3DCREATE_DISABLE_DRIVER_MANAGEMENT,
+        D3DCREATE_HARDWARE_VERTEXPROCESSING | D3DCREATE_NOWINDOWCHANGES,
         &params,
+        NULL,
         &dummyDevice
     ) != S_OK)
+        return false;
+
+    if (dummyDevice->GetSwapChain(0, &dummySwapchain) != S_OK)
         return false;
 
     return true;
@@ -135,6 +130,12 @@ void gui::DestroyDirectX() noexcept
     {
         dummyDevice->Release();
         dummyDevice = NULL;
+    }
+
+    if (dummySwapchain)
+    {
+        dummySwapchain->Release();
+        dummySwapchain = NULL;
     }
 
     if (d3d9)
@@ -170,10 +171,6 @@ void gui::SetupMenu(LPDIRECT3DDEVICE9 device) noexcept
     auto caps = D3DCAPS9{ };
     device->GetDeviceCaps(&caps);
     rtMax = caps.NumSimultaneousRTs;
-
-    auto swapchain = LPDIRECT3DSWAPCHAIN9{ };
-    device->GetSwapChain(0, &swapchain);
-    dx9::present_hook = safetyhook::create_inline((*(uintptr_t**)swapchain)[3], dx9::hook_present);
 
     auto params = D3DDEVICE_CREATION_PARAMETERS{ };
     device->GetCreationParameters(&params);

--- a/src/graphics/gui.h
+++ b/src/graphics/gui.h
@@ -21,8 +21,9 @@ namespace gui {
 
     // directX stuff
     inline LPDIRECT3DDEVICE9 device = nullptr;
-    inline LPDIRECT3DDEVICE9 dummyDevice = nullptr;
-    inline LPDIRECT3D9 d3d9 = nullptr;
+    inline LPDIRECT3DDEVICE9EX dummyDevice = nullptr;
+    inline LPDIRECT3DSWAPCHAIN9 dummySwapchain = nullptr;
+    inline LPDIRECT3D9EX d3d9 = nullptr;
     inline int rtMax = 1;
     inline int internal_resolution[2] = { 640, 480 };
     inline int output_resolution[2] = { 640, 480 };


### PR DESCRIPTION
also implements hooking ResetEx for when dx9ex api is used in upscalr2.